### PR TITLE
replace: deepcopy function with ox_lib deepclone

### DIFF
--- a/client/cl_boss.lua
+++ b/client/cl_boss.lua
@@ -11,7 +11,7 @@ end
 
 local function AddBossMenuItem(data, id)
     local menuID = id or #DynamicMenuItems + 1
-    DynamicMenuItems[menuID] = deepcopy(data)
+    DynamicMenuItems[menuID] = lib.table.deepclone(data)
     return menuID
 end
 

--- a/client/cl_gang.lua
+++ b/client/cl_gang.lua
@@ -11,7 +11,7 @@ end
 
 local function AddGangMenuItem(data, id)
     local menuID = id or #DynamicMenuItems + 1
-    DynamicMenuItems[menuID] = deepcopy(data)
+    DynamicMenuItems[menuID] = lib.table.deepclone(data)
     return menuID
 end
 

--- a/client/cl_utils.lua
+++ b/client/cl_utils.lua
@@ -1,24 +1,3 @@
-function deepcopy(orig, copies)
-    copies = copies or {}
-    local orig_type = type(orig)
-    local copy
-    if orig_type == 'table' then
-        if copies[orig] then
-            copy = copies[orig]
-        else
-            copy = {}
-            copies[orig] = copy
-            for orig_key, orig_value in next, orig, nil do
-                copy[deepcopy(orig_key, copies)] = deepcopy(orig_value, copies)
-            end
-            setmetatable(copy, deepcopy(getmetatable(orig), copies))
-        end
-    else -- number, string, boolean, etc
-        copy = orig
-    end
-    return copy
-end
-
 function comma_value(amount)
     local numChanged
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -104,9 +104,8 @@ function DepositMoney(src, amount, pDataType, type)
 	local player = exports.qbx_core:GetPlayer(src)
 
 	if not player.PlayerData[pDataType].isboss then ExploitBan(src, 'depositMoney Exploiting') return false end
-
+	local account = player.PlayerData[pDataType].name
 	if player.Functions.RemoveMoney("cash", amount) then
-		local account = player.PlayerData[pDataType].name
 		AddMoney(account, amount, type)
 		TriggerEvent('qb-log:server:CreateLog', 'gangmenu', 'Deposit Money', 'yellow', player.PlayerData.charinfo.firstname .. ' ' .. player.PlayerData.charinfo.lastname .. ' successfully deposited $' .. amount .. ' (' .. account .. ')', false)
 		exports.qbx_core:Notify(src, "You have deposited: $" ..amount, "success")


### PR DESCRIPTION
## Description

Replaces deepcopy function with deepclone function provided by ox_lib, and removes local function.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
