### PR TITLE
fix: GetPlayerIdentifierByType

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -8,9 +8,9 @@ local gangs = exports.qbx_core:GetGangs()
 local function exploitBan(id, reason)
     MySQL.insert('INSERT INTO bans (name, license, discord, ip, reason, expire, bannedby) VALUES (?, ?, ?, ?, ?, ?, ?)', {
         GetPlayerName(id),
-        exports.qbx_core:GetIdentifier(id, 'license'),
-        exports.qbx_core:GetIdentifier(id, 'discord'),
-        exports.qbx_core:GetIdentifier(id, 'ip'),
+        GetPlayerIdentifierByType(id, 'license'),
+        GetPlayerIdentifierByType(id, 'discord'),
+        GetPlayerIdentifierByType(id, 'ip'),
         reason,
         2147483647,
         'qb-management'


### PR DESCRIPTION
## Description

Replace the nonexistent exports.qbx_core:GetIdentifier with GetPlayerIdentifierByType

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
