### PR TITLE
fix: issue with boss menu exports

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -196,8 +196,8 @@ RegisterNetEvent('qbx_management:client:bossMenuRegistered', function(menuInfo)
     createZone(menuInfo)
 end)
 
-AddEventHandler('onResourceStart', function(resourceName)
-    if GetCurrentResourceName() ~= resourceName then return end
+AddEventHandler('onClientResourceStart', function(resourceName)
+    if cache.resource ~= resourceName then return end
     local menus = lib.callback.await('qbx_management:server:getBossMenus', false)
     for _, menuInfo in pairs(menus) do
         createZone(menuInfo)

--- a/server/main.lua
+++ b/server/main.lua
@@ -268,7 +268,7 @@ exports('RegisterBossMenu', registerBossMenu)
 -- Event Handlers
 -- Sets up inventory stashes for all groups
 AddEventHandler('onServerResourceStart', function(resourceName)
-	if resourceName ~= 'ox_inventory' and resourceName ~= GetCurrentResourceName() then return end
+	if resourceName ~= 'ox_inventory' and resourceName ~= cache.resource then return end
 	local data = config.menus
 	for groups, group in pairs(data) do
 		local prefix = group.group == 'gang' and 'gang_' or 'boss_'


### PR DESCRIPTION
## Description

- Switching the client `onResourceStart` to `onClientResourceStart` seems to have fixed the issue with the boss menu creation exports
- Also switched over the [GetCurrentResourceName](https://docs.fivem.net/natives/?_0xE5E9EBBB) to the ox_lib cache.resource

This should hopefully fix https://github.com/Qbox-project/qbx_core/issues/289

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
