### PR TITLE
fix: boss menu storage access

### DIFF
--- a/config/server.lua
+++ b/config/server.lua
@@ -8,18 +8,16 @@ return {
             size = vec3(1.5, 1.5, 1.5),
             rotation = 39.68,
             type = 'gang',
+            stashSlots = 100,
+            stashWeight = 4000000,
         },
         vagos = {
             coords = vec3(351.18, -2054.92, 22.09),
             size = vec3(1.5, 1.5, 1.5),
             rotation = 39.68,
             type = 'gang',
+            slots = 100,
+            weight = 4000000,
         },
-    },
-
-    -- Configure the stash here
-    storage = {
-        slots = 100,
-        weight = 4000000,
     },
 }

--- a/config/server.lua
+++ b/config/server.lua
@@ -7,13 +7,19 @@ return {
             coords = vec3(983.69, -90.92, 74.85),
             size = vec3(1.5, 1.5, 1.5),
             rotation = 39.68,
-            type = 'gang'
+            type = 'gang',
         },
         vagos = {
             coords = vec3(351.18, -2054.92, 22.09),
             size = vec3(1.5, 1.5, 1.5),
             rotation = 39.68,
-            type = 'gang'
-        }
-    }
+            type = 'gang',
+        },
+    },
+
+    -- Configure the stash here
+    storage = {
+        slots = 100,
+        weight = 4000000,
+    },
 }

--- a/server/main.lua
+++ b/server/main.lua
@@ -256,13 +256,15 @@ end)
 ---@field coords vector3 Coordinates of the zone
 ---@field size? vector3 uses vec3(1.5, 1.5, 1.5) if not set
 ---@field rotation? number uses 0.0 if not set
+---@field stashSlots? number uses 40 if not set
+---@field stashWeight? number uses 400000 if not set
 
 ---@param menuInfo MenuInfo
 local function registerBossMenu(menuInfo)
     menus[#menus + 1] = menuInfo
 	TriggerClientEvent('qbx_management:client:bossMenuRegistered', -1, menuInfo)
 	local prefix = menuInfo.type == 'gang' and 'gang_' or 'boss_'
-	exports.ox_inventory:RegisterStash(prefix..menuInfo.groupName, 'Stash: '..menuInfo.groupName, config.storage.slots, config.storage.weight, false)
+	exports.ox_inventory:RegisterStash(prefix..menuInfo.groupName, 'Stash: '..menuInfo.groupName, (menuInfo.stashSlots or 40), (menuInfo.stashWeight or 400000), false)
 end
 
 exports('RegisterBossMenu', registerBossMenu)
@@ -274,6 +276,6 @@ AddEventHandler('onServerResourceStart', function(resourceName)
 	local data = config.menus
 	for groups, group in pairs(data) do
 		local prefix = group.group == 'gang' and 'gang_' or 'boss_'
-		exports.ox_inventory:RegisterStash(prefix..groups, 'Stash: '..groups, config.storage.slots, config.storage.weight, false)
+		exports.ox_inventory:RegisterStash(prefix..groups, 'Stash: '..groups, (group.slots or 40), (group.weight or 400000), false)
 	end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -261,17 +261,19 @@ end)
 local function registerBossMenu(menuInfo)
     menus[#menus + 1] = menuInfo
 	TriggerClientEvent('qbx_management:client:bossMenuRegistered', -1, menuInfo)
+	local prefix = menuInfo.type == 'gang' and 'gang_' or 'boss_'
+	exports.ox_inventory:RegisterStash(prefix..menuInfo.groupName, 'Stash: '..menuInfo.groupName, config.storage.slots, config.storage.weight, false)
 end
 
 exports('RegisterBossMenu', registerBossMenu)
 
 -- Event Handlers
--- Sets up inventory stashes for all groups
+-- Sets up inventory stashes for all groups (Used by the config boss menu creation)
 AddEventHandler('onServerResourceStart', function(resourceName)
 	if resourceName ~= 'ox_inventory' and resourceName ~= cache.resource then return end
 	local data = config.menus
 	for groups, group in pairs(data) do
 		local prefix = group.group == 'gang' and 'gang_' or 'boss_'
-		exports.ox_inventory:RegisterStash(prefix..groups, 'Stash: '..groups, 100, 4000000, false)
+		exports.ox_inventory:RegisterStash(prefix..groups, 'Stash: '..groups, config.storage.slots, config.storage.weight, false)
 	end
 end)


### PR DESCRIPTION
## Description

- Fixes an issue where player is unable to access storage when using the export
- Add config and export options to change stash slots and weight

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
