### PR TITLE
fix: menu init and stash creation

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -66,7 +66,7 @@ local function employeeList(groupType)
             end,
         }
     end
-    
+
     lib.registerContext({
         id = 'memberListMenu',
         title = groupType == 'gang' and Lang:t('menu.manage_gang') or Lang:t('menu.manage_employees'),
@@ -192,17 +192,25 @@ local function createZone(zoneInfo)
     end
 end
 
-RegisterNetEvent('qbx_management:client:bossMenuRegistered', function(menuInfo)
-    createZone(menuInfo)
-end)
-
-AddEventHandler('onClientResourceStart', function(resourceName)
-    if cache.resource ~= resourceName then return end
+local function initZones()
     local menus = lib.callback.await('qbx_management:server:getBossMenus', false)
     for _, menuInfo in pairs(menus) do
         createZone(menuInfo)
     end
+end
+
+RegisterNetEvent('qbx_management:client:bossMenuRegistered', function(menuInfo)
+    createZone(menuInfo)
 end)
+
+AddEventHandler('onClientResourceStart', function(resource)
+    if cache.resource ~= resource then return end
+    initZones()
+end)
+
+RegisterNetEvent('QBCore:Client:OnJobUpdate', initZones)
+
+RegisterNetEvent('QBCore:Client:OnGangUpdate', initZones)
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     isLoggedIn = true

--- a/server/main.lua
+++ b/server/main.lua
@@ -271,11 +271,11 @@ exports('RegisterBossMenu', registerBossMenu)
 
 -- Event Handlers
 -- Sets up inventory stashes for all groups (Used by the config boss menu creation)
-AddEventHandler('onServerResourceStart', function(resourceName)
-	if resourceName ~= 'ox_inventory' and resourceName ~= cache.resource then return end
+AddEventHandler('onServerResourceStart', function(resource)
+	if resource ~= 'ox_inventory' and resource ~= cache.resource then return end
 	local data = config.menus
-	for groups, group in pairs(data) do
-		local prefix = group.group == 'gang' and 'gang_' or 'boss_'
-		exports.ox_inventory:RegisterStash(prefix..groups, 'Stash: '..groups, (group.slots or 40), (group.weight or 400000), false)
+	for groupName, menuInfo in pairs(data) do
+		local prefix = menuInfo.type == 'gang' and 'gang_' or 'boss_'
+		exports.ox_inventory:RegisterStash(prefix..groupName, 'Stash: '..groupName, (menuInfo.slots or 40), (menuInfo.weight or 400000), false)
 	end
 end)


### PR DESCRIPTION
## Description

Fixes two issues
- Menu creation when switching jobs or gangs
- Stash creation for the deprecated configuration menu settings

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
