### PR TITLE
feat(client/main):  Job Outfit Management

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
         "cache",
         "QBX",
         "locale",
-        "MySQL",
-        "qbx"
+        "MySQL"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "cache",
         "QBX",
         "locale",
-        "MySQL"
+        "MySQL",
+        "qbx"
     ]
 }

--- a/client/main.lua
+++ b/client/main.lua
@@ -156,15 +156,6 @@ function OpenBossMenu(groupType)
                 showHireMenu(groupType)
             end,
         },
-        {
-            title = locale('menu.outfit_management'),
-            description = groupType == 'gang' and locale('menu.gang_outfits') or locale('menu.job_outfits'),
-            icon = 'shirt',
-            event = 'illenium-appearance:client:OutfitManagementMenu',
-            args = {
-                type = qbx.string.capitalize(groupType)
-            }
-        },
     }
 
 		

--- a/client/main.lua
+++ b/client/main.lua
@@ -2,8 +2,29 @@ local config = require 'config.client'
 local JOBS = exports.qbx_core:GetJobs()
 local GANGS = exports.qbx_core:GetGangs()
 local isLoggedIn = LocalPlayer.state.isLoggedIn
+local dynamicMenuItems = {}
 
 lib.locale()
+
+-- Adds item to the boss/gang menu.
+---@param menuItem ContextMenuItem Requires args.type to be set to know which menu to place in.
+---@return number menuId ID of the menu item added
+local function addMenuItem(menuItem)
+    local menuId = #dynamicMenuItems + 1
+    if not menuId.args.type then return
+    dynamicMenuItems[menuId] = lib.table.deepclone(menuItem)
+    return menuId
+end
+exports('AddBossMenuItem', addMenuItem)
+exports('AddGangMenuItem', addMenuItem)
+
+-- Remove menu item at particular id
+---@param id number Menu ID to remove
+local function removeMenuItem(id)
+    dynamicMenuItems[id] = nil
+end
+exports('RemoveBossMenuItem', removeMenuItem)
+exports('RemoveGangMenuItem', removeMenuItem)
 
 -- Finds nearby players and returns a table of server ids
 ---@return table
@@ -145,6 +166,13 @@ function OpenBossMenu(groupType)
             }
         },
     }
+
+		
+    for _, menuItem in pairs(dynamicMenuItems) do
+        if string.lower(menuItem.args.type) == groupType then
+            bossMenu[#bossMenu + 1] = menuItem
+        end
+    end
 
     lib.registerContext({
         id = 'openBossMenu',

--- a/client/main.lua
+++ b/client/main.lua
@@ -11,7 +11,7 @@ lib.locale()
 ---@return number menuId ID of the menu item added
 local function addMenuItem(menuItem)
     local menuId = #dynamicMenuItems + 1
-    if not menuId.args.type then return end
+    if not menuItem.args.type then return end
     dynamicMenuItems[menuId] = lib.table.deepclone(menuItem)
     return menuId
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -141,7 +141,7 @@ function OpenBossMenu(groupType)
             icon = 'shirt',
             event = 'illenium-appearance:client:OutfitManagementMenu',
             args = {
-                type = groupType
+                type = qbx.string.capitalize(groupType)
             }
         },
     }

--- a/client/main.lua
+++ b/client/main.lua
@@ -11,7 +11,7 @@ lib.locale()
 ---@return number menuId ID of the menu item added
 local function addMenuItem(menuItem)
     local menuId = #dynamicMenuItems + 1
-    if not menuId.args.type then return
+    if not menuId.args.type then return end
     dynamicMenuItems[menuId] = lib.table.deepclone(menuItem)
     return menuId
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -40,7 +40,7 @@ local function manageEmployee(player, groupName, groupType)
 
     employeeMenu[#employeeMenu + 1] = {
         title = groupType == 'gang' and locale('menu.expel_gang') or locale('menu.fire_employee'),
-        icon = 'fa-solid fa-user-large-slash',
+        icon = 'user-large-slash',
         onSelect = function()
             lib.callback.await('qbx_management:server:fireEmployee', false, player.cid, groupType)
             OpenBossMenu(groupType)
@@ -122,7 +122,7 @@ function OpenBossMenu(groupType)
         {
             title = groupType == 'gang' and locale('menu.manage_gang') or locale('menu.manage_employees'),
             description = groupType == 'gang' and locale('menu.check_gang') or locale('menu.check_employee'),
-            icon = 'fa-solid fa-list',
+            icon = 'list',
             onSelect = function()
                 employeeList(groupType)
             end,
@@ -130,10 +130,19 @@ function OpenBossMenu(groupType)
         {
             title = groupType == 'gang' and locale('menu.hire_members') or locale('menu.hire_employees'),
             description = groupType == 'gang' and locale('menu.hire_gang') or locale('menu.hire_civilians'),
-            icon = 'fa-solid fa-hand-holding',
+            icon = 'hand-holding',
             onSelect = function()
                 showHireMenu(groupType)
             end,
+        },
+        {
+            title = locale('menu.outfit_management'),
+            description = groupType == 'gang' and locale('menu.gang_outfits') or locale('menu.job_outfits'),
+            icon = 'shirt',
+            event = 'illenium-appearance:client:OutfitManagementMenu',
+            args = {
+                type = groupType
+            }
         },
     }
 
@@ -142,6 +151,7 @@ function OpenBossMenu(groupType)
         title = groupType == 'gang' and string.upper(QBX.PlayerData.gang.label) or string.upper(QBX.PlayerData.job.label),
         options = bossMenu,
     })
+
     lib.showContext('openBossMenu')
 end
 
@@ -155,7 +165,7 @@ local function createZone(zoneInfo)
             options = {
                 {
                     name = zoneInfo.groupName..'_menu',
-                    icon = 'fa-solid fa-right-to-bracket',
+                    icon = 'right-to-bracket',
                     label = zoneInfo.type == 'gang' and locale('menu.gang_menu') or locale('menu.boss_menu'),
                     canInteract = function()
                         return zoneInfo.groupName == QBX.PlayerData[zoneInfo.type].name and QBX.PlayerData[zoneInfo.type].isboss

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,7 +8,6 @@ version '1.0.0'
 
 shared_scripts {
     '@ox_lib/init.lua',
-    '@qbx_core/modules/lib.lua',
 }
 
 client_scripts {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -8,6 +8,7 @@ version '1.0.0'
 
 shared_scripts {
     '@ox_lib/init.lua',
+    '@qbx_core/modules/lib.lua',
 }
 
 client_scripts {

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,7 +16,10 @@
         "gang_menu": "Gang Menu",
         "boss_menu": "Boss Menu",
         "gang_management": "[E] - Open Gang Management",
-        "boss_management": "[E] - Open Boss Management"
+        "boss_management": "[E] - Open Boss Management",
+        "outfit_management": "Outfit Management",
+        "job_outfits": "Manage Business Outfits",
+        "gang_outfits": "Manage Gang Outfits"
     },
     "error": {
         "cant_promote": "You can't change the grade of a person who's own grade is greater or equal to yours...",

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,10 +16,7 @@
         "gang_menu": "Gang Menu",
         "boss_menu": "Boss Menu",
         "gang_management": "[E] - Open Gang Management",
-        "boss_management": "[E] - Open Boss Management",
-        "outfit_management": "Outfit Management",
-        "job_outfits": "Manage Business Outfits",
-        "gang_outfits": "Manage Gang Outfits"
+        "boss_management": "[E] - Open Boss Management"
     },
     "error": {
         "cant_promote": "You can't change the grade of a person who's own grade is greater or equal to yours...",


### PR DESCRIPTION
## Description

- Reimplements the #32  that was rendered unusable when the original exports were removed
- Removed the unnecessary `fa-solid fa-` from the icons
- Implement the new lib module

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
