### PR TITLE
refactor(server/main): GetOfflinePlayer over FetchPlayerEntity

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -244,7 +244,7 @@ end
 ---@param player Player Player object of player initiating firing action
 ---@param groupType GroupType
 local function fireOfflineEmployee(source, employee, player, groupType)
-	local offlineEmployee = FetchPlayerEntityByCitizenId(employee)
+	local offlineEmployee = exports.qbx_core:GetOfflinePlayer(employee)
 	if not offlineEmployee[1] then
 		exports.qbx_core:Notify(source, locale('error.person_doesnt_exist'), 'error')
 		return false, nil

--- a/server/storage.lua
+++ b/server/storage.lua
@@ -17,13 +17,6 @@ function FetchPlayerEntitiesByGroup(name, type)
     return chars
 end
 
----Fetches DB Player Entity by CitizenId
----@param citizenId string
----@return table[]
-function FetchPlayerEntityByCitizenId(citizenId)
-    return MySQL.query.await('SELECT * FROM players WHERE citizenid = ? LIMIT 1', {citizenId})
-end
-
 ---Updates DB Player Entity
 ---@param citizenId string
 ---@param type GroupType


### PR DESCRIPTION
## Description

Replaces the use of FetchPlayerEntityByCitizenID with the GetOfflinePlayer export

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
