### PR TITLE
chore(server): compatibility for core v1.7.0

### DIFF
--- a/server/storage.lua
+++ b/server/storage.lua
@@ -16,12 +16,3 @@ function FetchPlayerEntitiesByGroup(name, type)
 
     return chars
 end
-
----Updates DB Player Entity
----@param citizenId string
----@param type GroupType
----@param role Gang | Job
----@return table[]
-function UpdatePlayerGroup(citizenId, type, role)
-    return MySQL.update.await('UPDATE players SET '..type..' = ? WHERE citizenid = ?', {json.encode(role), citizenId})
-end


### PR DESCRIPTION
- Needs to be tested before merging
- This PR only does the basics to remove the direct database write, it could go further by removing the read as well. It could go even further by fully supporting multi job/gang by reading from player_groups instead to take into account that a player can have multiple group entries. Or we could introduce a new core export to do the same SQL read and return all citizenids of players with a certain job/gang