### PR TITLE
feat(client): add backwards compat for netevents

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -232,6 +232,15 @@ RegisterNetEvent('qbx_management:client:bossMenuRegistered', function(menuInfo)
     createZone(menuInfo)
 end)
 
+if GetConvar('qbx:enablebridge', 'true') == 'true' then
+    RegisterNetEvent('qb-bossmenu:client:openMenu', function()
+        OpenBossMenu('job')
+    end)
+    RegisterNetEvent('qb-gangmenu:client:openMenu', function()
+        OpenBossMenu('gang')
+    end)
+end
+
 AddEventHandler('onClientResourceStart', function(resource)
     if cache.resource ~= resource then return end
     initZones()


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Addresses #57 by offering a netevent to support triggering of boss menu opening based on ACTIVE job/gang only if the qbx:enablebridge convar is not set to false.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
