### PR TITLE
fix(client/main): proper qb compat events

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -233,10 +233,10 @@ RegisterNetEvent('qbx_management:client:bossMenuRegistered', function(menuInfo)
 end)
 
 if GetConvar('qbx:enablebridge', 'true') == 'true' then
-    RegisterNetEvent('qb-bossmenu:client:openMenu', function()
+    RegisterNetEvent('qb-bossmenu:client:OpenMenu', function()
         OpenBossMenu('job')
     end)
-    RegisterNetEvent('qb-gangmenu:client:openMenu', function()
+    RegisterNetEvent('qb-gangmenu:client:OpenMenu', function()
         OpenBossMenu('gang')
     end)
 end


### PR DESCRIPTION
## Description

Fixes the namings of the qb compat events added earlier as in qb, these are pascal case. this should complete the work for #57

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
