### PR TITLE
refactor(server): remove storage layer in favor of new core export

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -20,7 +20,6 @@ client_scripts {
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
     'server/main.lua',
-    'server/storage.lua',
 }
 
 files {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -18,7 +18,6 @@ client_scripts {
 }
 
 server_scripts {
-    '@oxmysql/lib/MySQL.lua',
     'server/main.lua',
 }
 

--- a/server/main.lua
+++ b/server/main.lua
@@ -32,8 +32,7 @@ local function getMenuEntries(groupName, groupType)
 	return menuEntries
 end
 
--- Get a list of employees for a given group. Currently uses MySQL queries to return offline players.
--- Once an export is available to reliably return offline players this can rewriten.
+-- Get a list of employees for a given group.
 ---@param groupName string Name of job/gang to get employees of
 ---@param groupType GroupType
 ---@return table?

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,5 +1,5 @@
 lib.versionCheck('Qbox-project/qbx_management')
-if not lib.checkDependency('qbx_core', '1.7.0', true) then error() return end
+if not lib.checkDependency('qbx_core', '1.18.0', true) then error() return end
 if not lib.checkDependency('ox_lib', '3.13.0', true) then error() return end
 
 local config = require 'config.server'
@@ -16,7 +16,7 @@ end
 local function getMenuEntries(groupName, groupType)
 	local menuEntries = {}
 
-    local groupEntries = FetchPlayersInGroup(groupName, groupType)
+    local groupEntries = exports.qbx_core:GetGroupMembers(groupName, groupType)
     for i = 1, #groupEntries do
         local citizenid = groupEntries[i].citizenid
         local grade = groupEntries[i].grade

--- a/server/storage.lua
+++ b/server/storage.lua
@@ -1,8 +1,0 @@
----@alias GroupType 'gang' | 'job'
-
----@param name string
----@param type GroupType
----@return {citizenid: string, grade: integer}[]
-function FetchPlayersInGroup(name, type)
-    return MySQL.query.await("SELECT citizenid, grade FROM player_groups WHERE `group` = ? AND `type` = ?", {name, type})
-end


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Removes `server/storage.lua` in favor of the new `GetGroupMembers` export added in Qbox-project/qbx_core#534.
Also bumps `qbx_core` to 1.18.0 since the export is only available since that version.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
