### PR TITLE
fix: default return values on empty results

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -264,7 +264,6 @@ end)
 AddEventHandler('QBCore:Server:OnJobUpdate', function(source, job)
     if playersClockedIn[source] then
         onPlayerUnload(source)
-        return
     end
     local player = exports.qbx_core:GetPlayer(source)
     if player == nil then return end

--- a/server/storage.lua
+++ b/server/storage.lua
@@ -22,5 +22,5 @@ end
 ---@return table?
 function GetPlayerActivityData(citizenid, job)
     local result = MySQL.single.await('SELECT `last_checkin`, ROUND(COALESCE(SUM(last_checkout-last_checkin) / 3600, 0), 2) AS `hours` FROM `player_jobs_activity` WHERE `citizenid` = ? AND `job` = ? GROUP BY `citizenid`', { citizenid, job })
-    return { hours = result.hours, last_checkin = result.last_checkin and os.date(config.formatDateTime, result.last_checkin) or 'N/A' }
+    return { hours = result?.hours or 0, last_checkin = result?.last_checkin and os.date(config.formatDateTime, result.last_checkin) or 'N/A' }
 end


### PR DESCRIPTION
## Description
Fixes an issue if there was no rows the menu would not open correctly because i forgot to set default values in haste.
Also removed an return on job update that should have been removed because of `min duty log time config entry`

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
