### PR TITLE
fix(server/main): use safe navigation when asserting exports success

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -82,10 +82,10 @@ lib.callback.register('qbx_management:server:updateGrade', function(source, citi
 
     if groupType == 'job' then
         local success, errorResult = exports.qbx_core:AddPlayerToJob(citizenId, jobName, newGrade)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
     else
         local success, errorResult = exports.qbx_core:AddPlayerToGang(citizenId, jobName, newGrade)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
     end
 
     if employee then
@@ -114,14 +114,14 @@ lib.callback.register('qbx_management:server:hireEmployee', function(source, emp
 
     if groupType == 'job' then
         local success, errorResult = exports.qbx_core:AddPlayerToJob(target.PlayerData.citizenid, groupName, 0)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
         success, errorResult = exports.qbx_core:SetPlayerPrimaryJob(target.PlayerData.citizenid, groupName)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
     else
         local success, errorResult = exports.qbx_core:AddPlayerToGang(target.PlayerData.citizenid, groupName, 0)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
         success, errorResult = exports.qbx_core:SetPlayerPrimaryGang(target.PlayerData.citizenid, groupName)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
     end
 
     local playerFullName = player.PlayerData.charinfo.firstname..' '..player.PlayerData.charinfo.lastname
@@ -184,10 +184,10 @@ local function fireEmployee(employeeCitizenId, boss, groupName, groupType)
 
     if groupType == 'job' then
         local success, errorResult = exports.qbx_core:RemovePlayerFromJob(employee.PlayerData.citizenid, groupName)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
     else
         local success, errorResult = exports.qbx_core:RemovePlayerFromGang(employee.PlayerData.citizenid, groupName)
-        assert(success, errorResult.message)
+        assert(success, errorResult?.message)
     end
 
     if not employee.Offline then


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

Although `errorResult` won't be nil when `success` is false, but it will be evaluated as nil when `success` is true. That means we need to check for that or just use safe navigation.

Fixes #70

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
