### PR TITLE
Added access for export jobs created

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -143,6 +143,8 @@ end
 -- Opens main boss menu changing function based on the group provided.
 ---@param groupType GroupType
 function OpenBossMenu(groupType)
+    JOBS = exports.qbx_core:GetJobs()
+    GANGS = exports.qbx_core:GetGangs()
     if groupType ~= 'gang' and groupType ~= 'job' or not QBX.PlayerData[groupType].name or not QBX.PlayerData[groupType].isboss then return end
 
     local bossMenu = {

--- a/client/main.lua
+++ b/client/main.lua
@@ -80,6 +80,11 @@ end
 -- Allows selection of an employee to perform further actions
 ---@param groupType GroupType
 local function employeeList(groupType)
+    if groupType == 'job' then
+        JOBS = exports.qbx_core:GetJobs()
+    else
+        GANGS = exports.qbx_core:GetGangs()
+    end
     local employeesMenu = {}
     local groupName = QBX.PlayerData[groupType].name
     local employees = lib.callback.await('qbx_management:server:getEmployees', false, groupName, groupType)

--- a/client/main.lua
+++ b/client/main.lua
@@ -143,8 +143,6 @@ end
 -- Opens main boss menu changing function based on the group provided.
 ---@param groupType GroupType
 function OpenBossMenu(groupType)
-    JOBS = exports.qbx_core:GetJobs()
-    GANGS = exports.qbx_core:GetGangs()
     if groupType ~= 'gang' and groupType ~= 'job' or not QBX.PlayerData[groupType].name or not QBX.PlayerData[groupType].isboss then return end
 
     local bossMenu = {


### PR DESCRIPTION
## Description

Added the exports GetJobs & GetGangs inside the employeeList function in order to ensure that the jobs created with exports can use the boss menu.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
