### PR TITLE
fix(client/main): check if textui should be "toggled" based on config…

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -244,11 +244,9 @@ function OpenBossMenu(groupType)
         id = 'openBossMenu',
         title = groupType == 'gang' and string.upper(QBX.PlayerData.gang.label) or string.upper(QBX.PlayerData.job.label),
         options = bossMenu,
-        onExit = function()
-            if not config.useTarget then
-                lib.showTextUI(groupType == 'gang' and locale('menu.gang_management') or locale('menu.boss_management'))
-            end
-        end,
+        onExit = not config.useTarget and function()
+            lib.showTextUI(groupType == 'gang' and locale('menu.gang_management') or locale('menu.boss_management'))
+        end or nil,
     })
 
     lib.showContext('openBossMenu')

--- a/client/main.lua
+++ b/client/main.lua
@@ -245,7 +245,9 @@ function OpenBossMenu(groupType)
         title = groupType == 'gang' and string.upper(QBX.PlayerData.gang.label) or string.upper(QBX.PlayerData.job.label),
         options = bossMenu,
         onExit = function()
-            lib.showTextUI(groupType == 'gang' and locale('menu.gang_management') or locale('menu.boss_management'))
+            if not config.useTarget then
+                lib.showTextUI(groupType == 'gang' and locale('menu.gang_management') or locale('menu.boss_management'))
+            end
         end,
     })
 


### PR DESCRIPTION

## Description
Even when config.useTarget is set to true, on the exit of the context menu of the bossmenu a lib.showTextUI is always called and no check for target config is being done. Therefore if it's target based you're stuck with a textUI on your screen since it won't go away even if you move away from the point since the box zone isn't even made because the check there is correct.

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
